### PR TITLE
Fix issue with compatibility test and routes with `anyOf` in their schema

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -108,22 +108,27 @@ def test_api_path_parameters_are_compatible(oss_path, cloud_paths):
     ]
     oss_params = path[method].get("parameters", [])
 
+    def param_type_and_format(schema):
+        if "anyOf" in schema:
+            return [(item["type"], item.get("format")) for item in schema["anyOf"]]
+        else:
+            return (schema["type"], schema.get("format"))
+
     # check schemas
     cloud_params = {
         p["name"]: (
             p["in"],
             p["required"],
-            p["schema"]["type"],
-            p["schema"].get("format"),
+            *param_type_and_format(p["schema"]),
         )
         for p in cloud_params
     }
+
     oss_params = {
         p["name"]: (
             p["in"],
             p["required"],
-            p["schema"]["type"],
-            p["schema"].get("format"),
+            *param_type_and_format(p["schema"]),
         )
         for p in oss_params
     }


### PR DESCRIPTION
After merging the [concurrency v2 pull request](https://github.com/PrefectHQ/prefect/pull/10363) the compat tests in nebula [began failing](https://github.com/PrefectHQ/nebula/actions/runs/5755449462/job/15602886913). It appears this is because some of the v2 concurrency views accept a union of string and uuid, which comes out in the OpenAPI schema as a list in `anyOf` instead of a singular `type`. This updates the path parameters test to look to the `anyOf` field in the schema and fallback to `type`.