### PR TITLE
Ignore account and workspace on certain Cloud schemas

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -240,6 +240,13 @@ def test_oss_api_types_are_cloud_compatible(oss_type, cloud_schema):
     if name not in cloud_types:
         return
 
+    # some Cloud schemas will include account/workspace, but OSS will not, but this
+    # is not necessarily a compatibility issue if the schema is otherwise the same
+    INCLUDES_ACCOUNT_AND_WORKSPACE = [
+        "Automation",
+        "ReceivedEvent",
+    ]
+
     for master_key in ["properties", "required", "enum", "type"]:
         oss_props, cloud_props = (
             typ.get(master_key, {}),
@@ -247,7 +254,14 @@ def test_oss_api_types_are_cloud_compatible(oss_type, cloud_schema):
         )
 
         if not isinstance(oss_props, dict):
+            if name in INCLUDES_ACCOUNT_AND_WORKSPACE and master_key == "required":
+                if "account" in oss_props:
+                    oss_props.remove("account")
+                if "workspace" in oss_props:
+                    oss_props.remove("workspace")
+
             assert oss_props == cloud_props
+
             return
 
         for field_name, props in oss_props.items():


### PR DESCRIPTION
There will be some schemas in Cloud, like `Automation` and `ReceivedEvent` that
will require account/workspace, but these are still compatible with OSS.
