### PR TITLE
Adding `print`s that show the field names being compared

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -303,6 +303,10 @@ def test_api_request_bodies_are_compatible(oss_path, oss_schema, cloud_schema):
                 if oss_name in KNOWN_ALIASES[endpoint][method]:
                     oss_name = KNOWN_ALIASES[endpoint][method][oss_name]
 
+        # Note, this print is here intentionally to make it easier to understand test
+        # failures when looping over fields
+        print(oss_name)
+
         assert oss_name in cloud_props[1]
         (
             cloud_name,
@@ -382,6 +386,10 @@ def test_oss_api_types_are_cloud_compatible(oss_name_and_type, cloud_schema):
         ]
 
         for field_name, props in items:
+            # Note, this print is here intentionally to make it easier to understand
+            # test failures when looping over fields
+            print(field_name)
+
             assert field_name in cloud_props
 
             oss_options = set()

--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -305,7 +305,7 @@ def test_api_request_bodies_are_compatible(oss_path, oss_schema, cloud_schema):
 
         # Note, this print is here intentionally to make it easier to understand test
         # failures when looping over fields
-        print(oss_name)
+        print("parameter name:", oss_name)
 
         assert oss_name in cloud_props[1]
         (
@@ -388,7 +388,7 @@ def test_oss_api_types_are_cloud_compatible(oss_name_and_type, cloud_schema):
         for field_name, props in items:
             # Note, this print is here intentionally to make it easier to understand
             # test failures when looping over fields
-            print(field_name)
+            print("field name:", field_name)
 
             assert field_name in cloud_props
 


### PR DESCRIPTION
Because we loop over field names _within_ tests, rather than as pytest fixtures,
we don't know which field may have caused a failure.  These `print`s will help
for triaging compatibility issues.
