### PR TITLE
add `/.../download-logs-csv` to api version exclusions

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -196,6 +196,7 @@ def test_api_path_parameters_are_compatible(oss_path, cloud_paths):
         "events",
         "automations",
         "templates",
+        "download-logs-csv",
     ]
 
     if any(group in cloud_endpoint for group in ENDPOINT_GROUPS_WITHOUT_API_VERSION):


### PR DESCRIPTION
Add `/.../download-logs-csv` to the `ENDPOINT_GROUPS_WITHOUT_API_VERSION`. I believe this is correct it's okay that we're not passing the api version to this specific endpoint.

Was previously failing with:
```
FAILED test_oss_cloud_api_compatibility.py::test_api_path_parameters_are_compatible[GET: /api/flow_runs/{id}/download-logs-csv] - AssertionError: assert {'id': ('path', True, ('string', 'uuid'))} == {'id': ('path', True, ('string', 'uuid')), 'x-prefect-api-version': ('header', False, ('string', None))}
  Common items:
  {'id': ('path', True, ('string', 'uuid'))}
  Right contains 1 more item:
  {'x-prefect-api-version': ('header', False, ('string', None))}
  Full diff:
    {
     'id': ('path',
            True,
            ('string',
             'uuid')),
  -  'x-prefect-api-version': ('header',
  -                            False,
  -                            ('string',
  -                             None)),
    }
```