### PR TITLE
Add new logs route

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -196,6 +196,7 @@ def test_api_path_parameters_are_compatible(oss_path, cloud_paths):
         "events",
         "automations",
         "templates",
+        "download-logs",
         "download-logs-csv",
     ]
 


### PR DESCRIPTION
The `download-logs-csv` route was renamed, so now the list of endpoints that don't use an API version should include the new name, `download-logs`.