### PR TITLE
Ignore task_run_states routes in compatibility checks

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -43,6 +43,8 @@ OSS_PATH_IGNORE_REGEXES = {
     re.compile(r".*experimental.*"),
     # ignore the UI routes because OSS has it's own distinct UI
     re.compile(r"^(/api)?/ui.*"),
+    # task_run_states API permanently returns 410 Gone in Cloud (CLOUD-3414)
+    re.compile(r"^(/api)?/task_run_states.*"),
 }
 
 # OSS has support for some request properties that are not yet in Cloud, but


### PR DESCRIPTION
## Summary
- Skip `task_run_states` routes in OSS/Cloud API compatibility checks
- Cloud's task_run_states API permanently returns 410 Gone after the table was deprecated for ~10 months (CLOUD-3414)
- Companion to PrefectHQ/nebula#11165 which removed the task_run_state code references

🤖 Generated with [Claude Code](https://claude.com/claude-code)