### PR TITLE
Drop history_interval alias shim now that Cloud matches OSS

### DIFF
--- a/test_oss_cloud_api_compatibility.py
+++ b/test_oss_cloud_api_compatibility.py
@@ -359,9 +359,7 @@ def test_api_request_bodies_are_compatible(oss_path, oss_schema, cloud_schema):
         # failures when looping over fields
         print("parameter name:", oss_name)
 
-        if oss_name == "history_interval_seconds":
-            oss_name = "history_interval"  # cloud aliases this which doesn't appear in the schema
-        elif oss_name == "schema" and PREFECT_V2:
+        if oss_name == "schema" and PREFECT_V2:
             oss_name = "json_schema"  # UI schema validation doesnt really matter for 2.x OSS compat
 
         assert oss_name in cloud_props[1]


### PR DESCRIPTION
The request-body comparison special-cased the history endpoints:

```python
if oss_name == "history_interval_seconds":
    oss_name = "history_interval"  # cloud aliases this which doesn't appear in the schema
```

This existed because Cloud's `/flow_runs/history` and `/task_runs/history` named the param `history_interval` with `alias="history_interval_seconds"`, so its OpenAPI property rendered as `history_interval`. The shim rewrote OSS's `history_interval_seconds` back to `history_interval` to keep the comparison green after OSS renamed the param in [prefect#19659](https://github.com/PrefectHQ/prefect/pull/19659).

Cloud has now aligned with OSS: the param is `history_interval_seconds` with no alias, so Cloud's schema exposes `history_interval_seconds` directly. With the shim still in place the test fails the other way (`history_interval` is no longer a Cloud property), so this removes it.

Must merge alongside the Cloud-side change (nebula #11828) and the corresponding submodule bump.

Related to [CLOUD-3957](https://linear.app/prefect/issue/CLOUD-3957).

<details>
<summary>Session context</summary>

Verified locally by generating Cloud's schema (with the nebula fix) and OSS's schema from prefect@main, then running the suite. With the shim present the history request-body check fails (`assert 'history_interval' in cloud_props`); with it removed, the history checks pass. The only other local failure was a pre-existing fastapi/pydantic version-skew diff on `/flow_runs/{id}/input` that reproduces on the unmodified baseline and is unrelated to this change.
</details>